### PR TITLE
Document arrayHandler and its subcommands

### DIFF
--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2964,6 +2964,21 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
 /// | `each`      | Passes array of argument tuples to a handler.                                             | `$(array each <handlerName> <array>)`                 |
 /// | `map`       | Returns a new array based on applying <block> to <srcArray>                               | `$(array map <isIsolated> <name> <block> <srcArray>)` |
 /// | `mk`        | Iterates through arguments, checks if they are valid array elements, and groups them      | `$(array mk <block1> <block2> ... )`                  |
+/// 
+/// Some of these subcommands do a lot:
+/// 
+/// ## `ith` ##
+/// 
+/// All `ith` subcommands take a zero-indexed position argument to indicate where in the array the subcommand applies.
+/// Negative integers may be used to index from the tail of the array e.g. `-1` represents the final element, `-2` the penultimate element, and so on.
+/// The special tokens `head` and `tail` can be used instead of integer positions 0 and -1 respectively.
+/// 
+/// | Subcommand | Summary | Syntax |
+/// | ---------- | ------- | ------ |
+/// | `get`     | Returns the element at `<position>`.                          | `$(array ith get <position> $array);` |
+/// | `set`     | Replace the element at `<position>` with `<newEl>`.           | `$(array ith set <position> <newEl> $array);` |
+/// | `insert`  | Insert element `<newEl>` before the element at `<position>`.  | `$(array ith insert <position> <newEl> $array)` |
+/// | `remove`  | Remove the element at `<position>`.                           | `$(array ith remove <position> $array)` |
 pub fn arrayHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let root_anchor_span = t.clone().span();
   let mut stream = t.into_iter().peekable();

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2950,6 +2950,20 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
   }
   Ok((v_out, quote!{}))
 }
+
+/// Provides tools for working with arrays.
+/// 
+/// Arrays are represented by square brackets wrapping a block of one or more elements: `[{e1} {e2 e3}]`.
+/// 
+/// | Subcommand  | Summary                                                                                   | Syntax |
+/// | ----------  | -------                                                                                   | ------ |
+/// | `length`    | Return the length of the array.                                                           | `$(array length <array>)`                             |
+/// | `ith`       | Work with array using positional arguments. Operations: `get`, `set`, `remove`, `insert`. | `$(array ith <operation> <arguments>`                 |
+/// | `slice`     | TODO                                                                                      |         |
+/// | `concat`    | Concatenate the elements of two arrays together.                                          | `$(array concat <array1> <array2>)`                   |
+/// | `each`      | Passes array of argument tuples to a handler.                                             | `$(array each <handlerName> <array>)`                 |
+/// | `map`       | Returns a new array based on applying <block> to <srcArray>                               | `$(array map <isIsolated> <name> <block> <srcArray>)` |
+/// | `mk`        | Iterates through arguments, checks if they are valid array elements, and groups them      | `$(array mk <block1> <block2> ... )`                  |
 pub fn arrayHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let root_anchor_span = t.clone().span();
   let mut stream = t.into_iter().peekable();

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2963,7 +2963,12 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
 /// ## q mode ##
 /// 
 /// If the `array` token is followed immediately by a `q`, the command will treat its arguments as quoted and handle them as such.
-/// For example, `%(array q length %(quote {{1}}))` returns 1.
+/// For example:
+/// 
+///     %(array q length %(quote [ {foo} ])); // evaluates to 1;
+///     %(let x = { quux });
+///     %(array ith 2 [ {1} {foo bar baz} { $x } ]); // evaluates to { quux }
+///     %(array q ith 2 %(quote [ {1} {foo bar baz} { $x } ])); // evaluates to %(quote { $x }).
 /// 
 /// ## Commands ##
 /// 
@@ -2995,7 +3000,11 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
 /// ## `each` ##
 /// 
 /// Iterates through each item in <array> and runs the handler identified by <handlerName>, passing the item's sub-elements as arguments.
-/// For example,
+/// Useful for cases where `map` would be overkill, or for adding flexibility to `mk`-generated handlers' simple argument passing.
+/// See `examples/mem.rs` for a demonstration of the latter pattern.
+/// 
+/// Example:
+/// 
 ///  `$(array each run [ {$(let f = {3})} {$(let g = {4})} ] )` will set `$f` to 3 and `$g` to 4.
 /// 
 /// ## `map` ##

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2991,6 +2991,13 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
 /// | `set`       | Replace the element at `<position>` with `<newEl>`.           | `$(array ith set <position> <newEl> $array);` |
 /// | `insert`    | Insert element `<newEl>` before the element at `<position>`.  | `$(array ith insert <position> <newEl> $array)` |
 /// | `remove`    | Remove the element at `<position>`.                           | `$(array ith remove <position> $array)` |
+/// 
+/// ## `map` ##
+/// 
+/// If `should_isolate` is set to `true`, the code block is kept isolated from the running environment, if `false`, variables and
+/// handlers defined within the block will persist in the environment, allowing patterns like currying.
+/// 
+/// The `<name>` argument is used to set a variable representing the current element available for use within the code block `<block>`.
 pub fn arrayHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let root_anchor_span = t.clone().span();
   let mut stream = t.into_iter().peekable();

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2992,6 +2992,12 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
 /// | `insert`    | Insert element `<newEl>` before the element at `<position>`.  | `$(array ith insert <position> <newEl> $array)` |
 /// | `remove`    | Remove the element at `<position>`.                           | `$(array ith remove <position> $array)` |
 /// 
+/// ## `each` ##
+/// 
+/// Iterates through each item in <array> and runs the handler identified by <handlerName>, passing the item's sub-elements as arguments.
+/// For example,
+///  `$(array each run [ {{let f = 3;}} {{let g = 4;}} ] )` will set `$f` to 3 and `$g` to 4.
+/// 
 /// ## `map` ##
 /// 
 /// If `should_isolate` is set to `true`, the code block is kept isolated from the running environment, if `false`, variables and

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2953,19 +2953,31 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
 
 /// Provides tools for working with arrays.
 /// 
-/// Arrays are represented by square brackets wrapping a block of one or more elements: `[{e1} {e2 e3}]`.
+/// *Syntax*: `$(array <q>? <command> <arguments>)`
 /// 
-/// | Subcommand  | Summary                                                                                   | Syntax |
-/// | ----------  | -------                                                                                   | ------ |
+/// An array in `do_with_in!` is a Group (delimited token stream) containing zero or more Groups, and nothing else.
+/// The array commands simply manipulate these sequences of tokens to produce an evaluated result.
+/// All commands that "modify" an array in fact produce a new evaluated result.
+/// By convention, arrays are delimited by square brackets e.g. `[{100} {a b}]`.
+/// 
+/// ## q mode ##
+/// 
+/// If the `array` token is followed immediately by a `q`, the command will treat its arguments as quoted and handle them as such.
+/// For example, `%(array q length %(quote {{1}}))` returns 1.
+/// 
+/// ## Commands ##
+/// 
+/// | Command     | Summary                                                                                   | Syntax |
+/// | -------     | -------                                                                                   | ------ |
 /// | `length`    | Return the length of the array.                                                           | `$(array length <array>)`                             |
-/// | `ith`       | Work with array using positional arguments. Operations: `get`, `set`, `remove`, `insert`. | `$(array ith <operation> <arguments>`                 |
+/// | `ith`       | Work with array using positional arguments.                                               | `$(array ith <operation> <arguments>`                 |
 /// | `slice`     | TODO                                                                                      |         |
-/// | `concat`    | Concatenate the elements of two arrays together.                                          | `$(array concat <array1> <array2>)`                   |
+/// | `concat`    | Concatenate the elements of two or more arrays together.                                  | `$(array concat <array1> <array2> ...)`               |
 /// | `each`      | Passes array of argument tuples to a handler.                                             | `$(array each <handlerName> <array>)`                 |
-/// | `map`       | Returns a new array based on applying <block> to <srcArray>                               | `$(array map <isIsolated> <name> <block> <srcArray>)` |
+/// | `map`       | Returns a new array based on applying <block> to <srcArray>                               | `$(array map <should_isolate> <name> <block> <srcArray>)` |
 /// | `mk`        | Iterates through arguments, checks if they are valid array elements, and groups them      | `$(array mk <block1> <block2> ... )`                  |
 /// 
-/// Some of these subcommands do a lot:
+/// Some of these commands do a lot:
 /// 
 /// ## `ith` ##
 /// 
@@ -2973,12 +2985,12 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
 /// Negative integers may be used to index from the tail of the array e.g. `-1` represents the final element, `-2` the penultimate element, and so on.
 /// The special tokens `head` and `tail` can be used instead of integer positions 0 and -1 respectively.
 /// 
-/// | Subcommand | Summary | Syntax |
-/// | ---------- | ------- | ------ |
-/// | `get`     | Returns the element at `<position>`.                          | `$(array ith get <position> $array);` |
-/// | `set`     | Replace the element at `<position>` with `<newEl>`.           | `$(array ith set <position> <newEl> $array);` |
-/// | `insert`  | Insert element `<newEl>` before the element at `<position>`.  | `$(array ith insert <position> <newEl> $array)` |
-/// | `remove`  | Remove the element at `<position>`.                           | `$(array ith remove <position> $array)` |
+/// | Subcommand  | Summary | Syntax |
+/// | ---------   | ------- | ------ |
+/// | `get`       | Returns the element at `<position>`.                          | `$(array ith get <position> $array);` |
+/// | `set`       | Replace the element at `<position>` with `<newEl>`.           | `$(array ith set <position> <newEl> $array);` |
+/// | `insert`    | Insert element `<newEl>` before the element at `<position>`.  | `$(array ith insert <position> <newEl> $array)` |
+/// | `remove`    | Remove the element at `<position>`.                           | `$(array ith remove <position> $array)` |
 pub fn arrayHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let root_anchor_span = t.clone().span();
   let mut stream = t.into_iter().peekable();

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2996,7 +2996,7 @@ pub fn runMarkersHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
 /// 
 /// Iterates through each item in <array> and runs the handler identified by <handlerName>, passing the item's sub-elements as arguments.
 /// For example,
-///  `$(array each run [ {{let f = 3;}} {{let g = 4;}} ] )` will set `$f` to 3 and `$g` to 4.
+///  `$(array each run [ {$(let f = {3})} {$(let g = {4})} ] )` will set `$f` to 3 and `$g` to 4.
 /// 
 /// ## `map` ##
 /// 


### PR DESCRIPTION
List all the $(array) subcommands and explain them as best I can, providing some kind of syntax guidance.

Currently making a start on detailing the more complicated subcommands, such as `ith`, `map`, `each`.

- [x] List top-level subcommands
- [x] Document `ith`
- [x] Document `each`
- [x] Document `map`