### PR TITLE
Add short summaries for handler functions, and massage `genericDefaultHandlers` list

### DIFF
--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1816,7 +1816,12 @@ pub fn unescape<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, da
     Escaping::Backslash => actually_unescape(c, v, data, quote!{ Backslash #t }),
   }
 }
- 
+
+/// Evaluate block of code in place.
+/// 
+/// *Syntax*: $(run {<code>})
+/// 
+/// Useful for pass-through arguments when building handlers, or to evaluate an unquoted array.
 pub fn run<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut temp = t.into_iter();
   temp.next();
@@ -3417,7 +3422,7 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 /// | mk               | [mkHandler]               | A simple way to define new handlers at the use site                                                                                                                                |
 /// | quote            | [quote][quote()]          | In the lisp sense; renders the argument inert                                                                                                                                      |
 /// | unquote          | [unquote]                 | In the lisp sense; renders the argument ert                                                                                                                                        |
-/// | run              | [run]                     |                                                                                                                                                                                    |
+/// | run              | [run]                     | Evaluate block of code in place. Useful for pass-through arguments when building handlers, or to evaluate an unquoted array.                                                       |
 /// | array            | [arrayHandler]            | This handler has a bunch of subcommands and options; it is where most of the functionality for dealing with the representation we use of arrays is.                                |
 /// | import           | [importHandler]           | Basic file inclusion; path must be specified by quoted segments; special unquoted identier Base is used for the crate root; errors in included file will point at import statement |
 /// | withSigil        | [withSigilHandler]        |                                                                                                                                                                                    |

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1130,6 +1130,11 @@ pub fn concatHandlerInner<T: StartMarker + Clone>(c: Configuration<T>, v: Variab
   return Ok(out_str);
 }
 
+/// Concatenate two or more values together into a string.
+/// 
+/// *Syntax*: `%(concat <v1> <v2>...)`
+/// 
+/// Calls `to_string` method on values that are not string literals.
 pub fn concatHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut output = TokenStream2::new();
   let mut variables = v.clone();
@@ -3412,9 +3417,9 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 /// | Invoke as        | Defined by                | Note                                                                                                                                                                               |
 /// |------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 /// | if               | [ifHandler]               | Use as `$(if test { true branch } { false branch })`. The test will often be either a variable that has been set elsewhere or a `$(logic ...)` block.                              |
-/// | concat           | [concatHandler]           |                                                                                                                                                                                    |
 /// | let              | [letHandler]              | Create and assign a variable. Does NOT interpolate during either definition or use.                                                                                  |
 /// | var              | [varHandler]              | Create and assign a variable. DOES interpolate during both definition and use.                                                                                     |
+/// | concat           | [concatHandler]           | Concatenate two or more values together into a string. Calls `to_string` method on values that are not string literals.                                                            |
 /// | naiveStringifier | [naiveStringifierHandler] |                                                                                                                                                                                    |
 /// | string_to_ident  | [string_to_identHandler]  |                                                                                                                                                                                    |
 /// | arithmetic       | [arithmeticHandler]       | You have to specify the type of the number eg i8, usize, f64                                                                                                                       |

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -3436,8 +3436,8 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 /// | array            | [arrayHandler]            | This handler has a bunch of subcommands and options; it is where most of the functionality for dealing with the representation we use of arrays is.                                |
 /// | import           | [importHandler]           | Basic file inclusion; path must be specified by quoted segments; special unquoted identier Base is used for the crate root; errors in included file will point at import statement |
 /// | withSigil        | [withSigilHandler]        |                                                                                                                                                                                    |
-/// | marker           | [markerHandler]           | This handler is for embedding data in one invocation of do_with_in! in a way that can be used in other invocations.                                                                |
-/// | runMarkers       | [runMarkersHandler]       | This handler loads data into the environment from other invocations of do_with_in!.                                                                                                |
+/// | marker           | [markerHandler]           | Embed data in one invocation of `do_with_in!` in a way that can be used in other invocations.                                                                                      |
+/// | runMarkers       | [runMarkersHandler]       | Load data into the environment from other invocations of `do_with_in!`.                                                                                                            |
 pub fn genericDefaultHandlers<'a, T: 'static + StartMarker + Clone>() -> Handlers<'a, T> {
   let mut m: HashMap<String, (Box<&Handler<T>>, Option<TokenStream2>)> = HashMap::new();
   m.insert(String::from("if"), ((Box::new(&ifHandler), None)));

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1007,7 +1007,13 @@ impl<'a, T: 'static + StartMarker + Clone> Default for Variables<'a, T> {
 pub type Handler<T: StartMarker + Clone> = dyn Fn(Configuration<T>, Variables<T>, Option<TokenStream2>, TokenStream2) -> StageResult<T>;
 pub type Handlers<'a, T: StartMarker + Clone> = HashMap<String, (Box<&'a Handler<T>>, Option<TokenStream2>)>;
 
-
+/// Conditionally execute one of two branches, depending on the result of a test expression.
+/// 
+/// *Syntax*: `$(if {<testBlock>} {<trueBlock>} {<falseBlock})`
+/// 
+/// The test will often be either a variable that has been set elsewhere or a `$(logic ...)` block.
+/// It *must* evaluate to either `true` or `false`.
+/// Only one of the branches is expanded and executed, so this can be used to protect the other branch from blowing up.
 pub fn ifHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut stream = t.into_iter();
   let if_anchor = stream.next().span();
@@ -3437,7 +3443,7 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 ///
 /// | Invoke as        | Defined by                | Note                                                                                                                                                                               |
 /// |------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-/// | if               | [ifHandler]               | Use as `$(if test { true branch } { false branch })`. The test will often be either a variable that has been set elsewhere or a `$(logic ...)` block.                              |
+/// | if               | [ifHandler]               | Conditionally execute one of two branches, depending on the result of a test expression. Use as `$(if {test} { true branch } { false branch })`.                                   |
 /// | let              | [letHandler]              | Create and assign a variable. Does NOT interpolate during either definition or use.                                                                                  |
 /// | var              | [varHandler]              | Create and assign a variable. DOES interpolate during both definition and use.                                                                                     |
 /// | concat           | [concatHandler]           | Concatenate two or more values together into a string. Calls `to_string` method on values that are not string literals.                                                            |

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1847,6 +1847,11 @@ pub fn run<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Op
   do_with_in_explicit2(in_it, c.clone(), v2)
 }
 // TODO: Remeber to check for whether 'quote' ends up stacking up due to everything inside the $(...) being passed through the t
+/// In the lisp sense; renders its argument inert.
+/// 
+/// *Syntax*: `$(quote <arg>)`
+/// 
+/// Allows an expression to be created in one place, passed around as-is, and eventually unwrapped with [unquote] for expansion and evaluation.
 pub fn quote<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   // Remember that the first token of t should already be 'quote'
   let out = match c.sigil {
@@ -1858,6 +1863,11 @@ pub fn quote<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:
   Ok((v, out))
 }
 
+/// In the lisp sense; renders its argument ert.
+/// 
+/// *Syntax*: `$(unquote <quotedArg>)`
+/// 
+/// Unwraps an expression created with [quote], allowing it to be expanded and run in a different context from its definition.
 pub fn unquote<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut out: TokenStream2 = quote!{compile_error!{"Nothing here."}};
   let sig_char = match format!("{}", c.sigil).pop() {

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1156,6 +1156,12 @@ pub fn concatHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T
   return Ok((v, output));
 }
 
+/// Return a string representation of a `do-with-in!` value.
+/// 
+/// *Syntax*: `$(naiveStringifier <value>)`
+/// 
+/// As the name implies, not all cases may be elegantly handled, and the output from this handler may change without warning.
+/// Potentially useful nonetheless for print debugging of complex structures and the like.
 pub fn naiveStringifierHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut stream = match do_with_in_explicit2(t, c.clone(), v.clone()) {
     Ok((_, x)) => x,
@@ -3425,8 +3431,8 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 /// | let              | [letHandler]              | Create and assign a variable. Does NOT interpolate during either definition or use.                                                                                  |
 /// | var              | [varHandler]              | Create and assign a variable. DOES interpolate during both definition and use.                                                                                     |
 /// | concat           | [concatHandler]           | Concatenate two or more values together into a string. Calls `to_string` method on values that are not string literals.                                                            |
-/// | naiveStringifier | [naiveStringifierHandler] |                                                                                                                                                                                    |
 /// | arithmetic       | [arithmeticHandler]       | You have to specify the type of the number eg i8, usize, f64                                                                                                                       |
+/// | naiveStringifier | [naiveStringifierHandler] | Return a string representation of a `do-with-in!` value. Per the name: may not cover all cases.                                                                                    |
 /// | string_to_ident  | [string_to_identHandler]  | Turn a string into a named identifier, allowing dynamic identifier names.                                                                                                          |
 /// | logic            | [logicHandler]            | Sublanguage: nesting with parenthesis; logic ops ⌜&⌝, ⌜\|⌝, ⌜^⌝, ⌜=⌝, unary ⌜!⌝, ⌜true⌝, ⌜false⌝; numeric comparisons with numbers ⌜>⌝, ⌜>=⌝, ⌜=⌝, ⌜<=⌝, ⌜<⌝, ⌜!=⌝                 |
 /// | mk               | [mkHandler]               | A simple way to define new handlers at the use site                                                                                                                                |

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2739,6 +2739,13 @@ pub fn assignmentInternalHandler<T: StartMarker + Clone>(c: Configuration<T>, v:
   }
   Ok((variables, quote!{}))
 }
+/// Create and assign variables. Does NOT interpolate during either definition or use.
+/// 
+/// *Syntax*: `%(let <ident> = <value>)`
+/// 
+/// A variable in `do-with-in!` is an identifier with a prepended sigil.
+/// The value assigned to a variable defined with `let` will remain unchanged before it is used.
+/// Internally, `let` is a wrapper around [assignmentInternalHandler];
 pub fn letHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data: Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut stream = t.into_iter();
   check_token_ret!(v, Some(TokenTree2::Ident(it)), stream.next(), "Expecting 'let'.", it.to_string() == "let", "Expecting 'let'.");
@@ -2747,6 +2754,13 @@ pub fn letHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, 
   assignmentInternalHandler(c, v, temp, false, false)
 }
 
+/// Create and assign variables. DOES interpolate during both definition and use.
+/// 
+/// *Syntax*: `$(var <ident> = <value>)`
+/// 
+/// A variable in `do-with-in!` is an identifier with a prepended sigil.
+/// Variables set with `var` can make reference to other metaprogramming variables.
+/// Internally, `var` is a wrapper around [assignmentInternalHandler];
 pub fn varHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut stream = t.into_iter();
   check_token_ret!(v, Some(TokenTree2::Ident(it)), stream.next(), "Expecting 'var'.", it.to_string() == "var", "Expecting 'var'.");
@@ -3393,9 +3407,9 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 /// | Invoke as        | Defined by                | Note                                                                                                                                                                               |
 /// |------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 /// | if               | [ifHandler]               | Use as `$(if test { true branch } { false branch })`. The test will often be either a variable that has been set elsewhere or a `$(logic ...)` block.                              |
-/// | let              | [letHandler]              | Internally, a wrapper around [assignmentInternalHandler]; do not interpolate on definition or use                                                                                  |
-/// | var              | [varHandler]              | Internally, a wrapper around [assignmentInternalHandler]; interpolate on definition and on use                                                                                     |
 /// | concat           | [concatHandler]           |                                                                                                                                                                                    |
+/// | let              | [letHandler]              | Create and assign a variable. Does NOT interpolate during either definition or use.                                                                                  |
+/// | var              | [varHandler]              | Create and assign a variable. DOES interpolate during both definition and use.                                                                                     |
 /// | naiveStringifier | [naiveStringifierHandler] |                                                                                                                                                                                    |
 /// | string_to_ident  | [string_to_identHandler]  |                                                                                                                                                                                    |
 /// | arithmetic       | [arithmeticHandler]       | You have to specify the type of the number eg i8, usize, f64                                                                                                                       |

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1752,9 +1752,12 @@ pub fn arithmeticHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variabl
   Ok((v, output))
 }
 
-/// A handler that lets the end user change which sigil the code inside it uses.
+/// Redefine which sigil to use within the scope of the handler.
+/// 
+/// *Syntax*: `$(withSigil <newSigil> <codeUsingNewSigil>)`
 ///
 /// In a context where the sigil was `$` and you want to complicatedly generate a lot of macro_rules! code based on some table, you might use it like so
+/// 
 /// ```rust,ignore
 /// // various other code
 /// $(withSigil %
@@ -3466,8 +3469,8 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 /// | unquote          | [unquote]                 | In the lisp sense; renders the argument ert                                                                                                                                        |
 /// | run              | [run]                     | Evaluate block of code in place. Useful for pass-through arguments when building handlers, or to evaluate an unquoted array.                                                       |
 /// | array            | [arrayHandler]            | This handler has a bunch of subcommands and options; it is where most of the functionality for dealing with the representation we use of arrays is.                                |
-/// | withSigil        | [withSigilHandler]        |                                                                                                                                                                                    |
 /// | import           | [importHandler]           | Basic file inclusion. Path to file is defined by a series of quoted segments, relative path can be used if `file:` hint is set in front matter.                                    |
+/// | withSigil        | [withSigilHandler]        | Redefine which sigil to use within the scope of the handler. Sigil can be one of `$`, `%`, `#`, or `~`.                                                                            |
 /// | marker           | [markerHandler]           | Embed data in one invocation of `do_with_in!` in a way that can be used in other invocations.                                                                                      |
 /// | runMarkers       | [runMarkersHandler]       | Load data into the environment from other invocations of `do_with_in!`.                                                                                                            |
 pub fn genericDefaultHandlers<'a, T: 'static + StartMarker + Clone>() -> Handlers<'a, T> {

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1168,6 +1168,11 @@ pub fn naiveStringifierHandler<T: StartMarker + Clone>(c: Configuration<T>, v: V
   Ok((v, quote!{ #output }))
 }
 
+/// Turn a string into a named identifier.
+/// 
+/// *Syntax*: `$(string_to_ident <stringValue>)`
+/// 
+/// This allows the creation and reference of dynamic identifier names. Argument must be a string or an object with the `to_string` method.
 pub fn string_to_identHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut output = TokenStream2::new();
   let mut variables = v.clone();
@@ -3421,8 +3426,8 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 /// | var              | [varHandler]              | Create and assign a variable. DOES interpolate during both definition and use.                                                                                     |
 /// | concat           | [concatHandler]           | Concatenate two or more values together into a string. Calls `to_string` method on values that are not string literals.                                                            |
 /// | naiveStringifier | [naiveStringifierHandler] |                                                                                                                                                                                    |
-/// | string_to_ident  | [string_to_identHandler]  |                                                                                                                                                                                    |
 /// | arithmetic       | [arithmeticHandler]       | You have to specify the type of the number eg i8, usize, f64                                                                                                                       |
+/// | string_to_ident  | [string_to_identHandler]  | Turn a string into a named identifier, allowing dynamic identifier names.                                                                                                          |
 /// | logic            | [logicHandler]            | Sublanguage: nesting with parenthesis; logic ops ⌜&⌝, ⌜\|⌝, ⌜^⌝, ⌜=⌝, unary ⌜!⌝, ⌜true⌝, ⌜false⌝; numeric comparisons with numbers ⌜>⌝, ⌜>=⌝, ⌜=⌝, ⌜<=⌝, ⌜<⌝, ⌜!=⌝                 |
 /// | mk               | [mkHandler]               | A simple way to define new handlers at the use site                                                                                                                                |
 /// | quote            | [quote][quote()]          | In the lisp sense; renders the argument inert                                                                                                                                      |

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2444,6 +2444,16 @@ macro_rules! getCode {
     };
   };
 }
+/// Import the contents of a file.
+/// 
+/// *Syntax*: `$(import <pathSegment>...)`
+/// 
+/// Path is specified by quoted segments; special unquoted identier `Base` is used for the crate root.
+/// Takes into account the `file:` hint in `do-with-in!` front matter to allow relative path addressing.
+///
+/// Errors in the imported file will point at the import statement, rather than within the file itself.
+/// 
+/// See tests for more examples of file importing.
 pub fn importHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data: Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   getCode!(stream, tokens, anchor_span, cnew, c, path, v, t);
   let mut thing = TokenStream2::new();
@@ -3456,8 +3466,8 @@ fn uq(s: Sigil, t: TokenStream2) -> std::result::Result<TokenStream2, &'static s
 /// | unquote          | [unquote]                 | In the lisp sense; renders the argument ert                                                                                                                                        |
 /// | run              | [run]                     | Evaluate block of code in place. Useful for pass-through arguments when building handlers, or to evaluate an unquoted array.                                                       |
 /// | array            | [arrayHandler]            | This handler has a bunch of subcommands and options; it is where most of the functionality for dealing with the representation we use of arrays is.                                |
-/// | import           | [importHandler]           | Basic file inclusion; path must be specified by quoted segments; special unquoted identier Base is used for the crate root; errors in included file will point at import statement |
 /// | withSigil        | [withSigilHandler]        |                                                                                                                                                                                    |
+/// | import           | [importHandler]           | Basic file inclusion. Path to file is defined by a series of quoted segments, relative path can be used if `file:` hint is set in front matter.                                    |
 /// | marker           | [markerHandler]           | Embed data in one invocation of `do_with_in!` in a way that can be used in other invocations.                                                                                      |
 /// | runMarkers       | [runMarkersHandler]       | Load data into the environment from other invocations of `do_with_in!`.                                                                                                            |
 pub fn genericDefaultHandlers<'a, T: 'static + StartMarker + Clone>() -> Handlers<'a, T> {


### PR DESCRIPTION
The handler functions should all have some amount of documentation against them, at least a one-liner saying what they do, and it should correspond somewhat with the `genericDefaultHandlers` table that summarizes what gets included by default.

This makes for a bit of redundancy between the Readme, the `genericDefaultHandlers` table, and the function documentation itself, but that's probably alright:

- Readme description of handlers is aiming for a tutorial-level introduction
- `genericDefaultHandlers` table puts all the handlers together for quick overview.
- function comments should eventually be definitive, with edge cases, examples, rationale etc

I don't think we have the perfect docs, yet, but this means we now have at least a little something on every default handler.