### PR TITLE
Arithmetic EBNF description

### DIFF
--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1751,13 +1751,19 @@ fn arithmeticInternal<T: StartMarker + Clone, N: Copy + std::str::FromStr + std:
 ///     <binary_operator> ::= "+" | "-" | "*" | "/" | "%" | "|" | "^" | "&" | ">" | "<"
 ///     <val> ::= <ws>* (<sub_expr> | <number>) <ws>*
 ///     <sub_expr> ::= "(" <command> ")"
-///     <number> ::= <integer> <fraction>? <exponent>? ("_"? <type>)?
+///     <number> ::= (<integer> | <float>) ("_"? <type>)?
+///     <float> ::= <dec_integer> <fraction>? <exponent>?
 ///     <fraction> ::= "." <digit>+
-///     <integer> ::= "-"? (<digit> | <one_to_nine> ("_"? <digit>)+)
+///     <exponent> ::= ("e" | "E") ("+" | "-")? <digit>+
+///     <integer> ::= <dec_integer> | <hex_integer> | <bin_integer>
+///     <dec_integer> ::= "-"? (<digit> | <one_to_nine> ("_"? <digit>)+)
+///     <hex_integer> ::= "0" ("x" | "X") ("_"? <hex_digit>)+
+///     <hex_digit> ::= <digit> | [a-f] | [A-F]
+///     <bin_integer> ::= "0" ("b" | "B") ("_"? <bin_digit>)+
+///     <bin_digit> ::= "0" | "1"
 ///     <digit> ::= "0" | <one_to_nine>
 ///     <one_to_nine> ::= [1-9]
-///     <exponent> ::= ("e" | "E") ("+" | "-")? <digit>+
-///     <ws> ::= " "
+///     <ws> ::= ? Rust-accepted whitespace tokens ?
 /// 
 /// Current implementation leans on the [`syn`](https://docs.rs/syn/latest/syn/index.html) literal parsing tooling,
 /// and may be subject to change.

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1567,7 +1567,7 @@ fn arithmeticInternal<T: StartMarker + Clone, N: Copy + std::str::FromStr + std:
                     operator = Some(Operator::Or);
                   },
                   it   => {
-                    let msg = format!("Expected operator such as +, *, -, /, %, >>, or <<, got {}", it);
+                    let msg = format!("Expected operator such as +, *, -, /, %, >, or <, got {}", it);
                     return Err(syn::parse::Error::new_spanned(token, msg));
                   },
                 }
@@ -1733,8 +1733,8 @@ fn arithmeticInternal<T: StartMarker + Clone, N: Copy + std::str::FromStr + std:
 /// | `\|`      | Bitwise OR            |  |
 /// | `^`       | Bitwise XOR           |  |
 /// | `&`       | Bitwise AND           |  |
-/// | `>`       | Bitwise right shift   |  |
-/// | `<`       | Bitwise left shift    |  |
+/// | `>`       | Bitwise right shift   | Note single `>` rather than more conventional `>>` |
+/// | `<`       | Bitwise left shift    | Note single `<` rather than more conventional `<<` |
 /// | `not`     | Bitwise NOT           | Unary. |
 /// | `size_of` | Size of type in bytes | Unary. Uses [https://doc.rust-lang.org/std/mem/fn.size_of.html] |
 /// 


### PR DESCRIPTION
Replace slightly ad-hoc description of arithmetic sublanguage with an EBNF description that *may* be more succinct and accurate, fingers crossed.

- Note reliance on `syn` literal parsing
- Create table for arithmetic operators
- Be clearer about what suffix-annotated literals look like.

It's... fine. Not perfect, but a start. Specifically, I'm guesstimating what `syn` parses into a valid numeric literal, for instance, where are underscores allowed? I used http://bnfplayground.pauliankline.com/ to check my EBNF working and to generate supposedly well-formed expressions.