### PR TITLE
Refine rustdoc output for do_with_in_base

### DIFF
--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -902,9 +902,12 @@ impl<T: StartMarker + Clone> Configuration<T> {
   }
 }
 
+/// Holds the assignable state for a `do_with_in!` block.
 #[derive(Clone)]
 pub struct Variables<'a, T: StartMarker + Clone> {
+  /// Handler functions available at this point in processing.
   pub handlers:    Handlers<'a, T>,
+  /// Values assigned through [letHandler] or [varHandler].
   pub variables:   HashMap<String, (TokenStream2, bool)>,
 }
 

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -69,10 +69,14 @@ impl Default for Sigil {
   }
 }
 
+/// Escape sequence style set in [Configuration].
 #[derive(Debug,Copy,Clone,PartialEq,Eq)]
 pub enum Escaping {
+  /// No escape sequence is allowed.
   None,
+  /// Escape sequence is a backslash followed by a sigil e.g. `\%` or `\#`.
   Backslash,
+  /// Escape sequence is two of the assigned sigils in a row e.g. `$$` or `~~`.
   Double,
 }
 

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -71,9 +71,13 @@ impl Default for Sigil {
 }
 
 /// Escape sequence style set in [Configuration].
+/// 
+/// Sigils that precede a name or number, or a group are evaluated as variables and handlers respectively. To treat these sigils
+/// instead as unchanged parts of a token an escape sequence can be used. Sigils that do not directly precede a name, number, or
+/// group are always left unchanged.
 #[derive(Debug,Copy,Clone,PartialEq,Eq)]
 pub enum Escaping {
-  /// No escape sequence is allowed.
+  /// There are no escape sequences; sigils are always treated normally.
   None,
   /// Escape sequence is a backslash followed by a sigil e.g. `\%` or `\#`.
   Backslash,

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -2889,6 +2889,13 @@ pub fn handleMkHandlerRunner<T: 'static + StartMarker + Clone>(c: Configuration<
     return Err((v, quote_spanned!{sp=> #msg }));
   }
 }
+
+/// A simple way to define new handlers at the use site.
+/// 
+/// *Syntax*: `%(mk <ident> <block>)`
+/// 
+/// Once defined, it can be called like any other handler: `%(<ident> {<arg1>}... )`.
+/// On calling, its positional numbered parameters can be referenced via `%1`, `%2` etc.
 pub fn mkHandler<T: 'static + StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data: Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut variables = v.clone();
   let mut it = t.clone().into_iter();

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1017,7 +1017,9 @@ impl<'a, T: 'static + StartMarker + Clone> Default for Variables<'a, T> {
   }
 }
 
+/// Function that processes a token stream and return a [Result] holding the currently assigned variables & the remaining token stream.
 pub type Handler<T: StartMarker + Clone> = dyn Fn(Configuration<T>, Variables<T>, Option<TokenStream2>, TokenStream2) -> StageResult<T>;
+/// A [HashMap] of [Handler] functions, keyed by a [String] token. Used in [Variable].
 pub type Handlers<'a, T: StartMarker + Clone> = HashMap<String, (Box<&'a Handler<T>>, Option<TokenStream2>)>;
 
 /// Conditionally execute one of two branches, depending on the result of a test expression.

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -25,6 +25,7 @@ use std::fmt::format;
 
 use bimap::BiMap;
 
+/// User-configurable options for sigil control character, one of `$`, `%`, `#`, or `~`.
 #[derive(Debug,Copy,Clone,PartialEq,Eq)]
 pub enum Sigil {
   Dollar,

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -96,11 +96,16 @@ impl Default for Escaping {
   }
 }
 
+/// Holds configurable state for `do_with_in` processing.
 #[derive(Debug,Clone)]
 pub struct Configuration<Start: StartMarker> where Start: Clone {
+  /// Whether front matter is taken into account. Default is `true` when using `do_with_in!` proc_macro.
   pub allow_prelude: bool,
+  /// Control character to use within `do_with_in!` block. Defaults to `$`. Can be set in front matter.
   pub sigil: Sigil,
+  /// Pattern used as escape sequence. Can be set in front matter.
   pub escaping_style: Escaping,
+  /// Allows use of relative path when calling `import`. Can be set in front matter.
   pub file: Option<String>,
   pub rest: Option<TokenStream2>,
   _do: PhantomData<Start>,

--- a/do_with_in_base/src/lib.rs
+++ b/do_with_in_base/src/lib.rs
@@ -1111,6 +1111,7 @@ fn tokenstreamToBool(stream: TokenStream2) -> std::result::Result<bool, String> 
   }
 }
 
+#[doc(hidden)]
 pub fn concatHandlerInner<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, t: TokenStream2) -> syn::parse::Result<String> {
   let mut accumulator: Vec<String> = Vec::new();
   for token in t.into_iter() {
@@ -1217,6 +1218,7 @@ pub fn string_to_identHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Va
   return Ok((v, output));
 }
 
+#[doc(hidden)]
 pub fn forHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data:Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let mut output = TokenStream2::new();
   let mut variables = v.clone();
@@ -2797,6 +2799,7 @@ pub fn internalFnRunner<T: StartMarker + Clone>(c: Configuration<T>, v: Variable
     },
   }
 }
+#[doc(hidden)]
 pub fn fnHandler<T: 'static + StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, data: Option<TokenStream2>, t: TokenStream2) -> StageResult<T> {
   let sp = t.clone().span();
   let mut variables = v.clone();
@@ -2918,6 +2921,8 @@ enum LetState {
   Name(String),
   NamePostEquals(String),
 }
+
+#[doc(hidden)]
 pub fn assignmentInternalHandler<T: StartMarker + Clone>(c: Configuration<T>, v: Variables<T>, t: TokenStream2, interp_first: bool, interp_after: bool) -> StageResult<T> {
   let mut variables = v.clone();
   let mut state: LetState = LetState::Nothing;


### PR DESCRIPTION
Documentation gardening of the following:

- Summarise the `mkHandler` function
- Describe the structs `Configuration` and `Variables`
- Annotate the public enums `Sigil` and `Escaping`
- Hide inner handlers `concatHandlerInner` and `assignmentInternalHandler` from public docs
- Hide WIP handlers `fnHandler` and `forHandler`
- Describe the type aliases `Handler` and `Handlers`